### PR TITLE
Update apo.obo

### DIFF
--- a/apo.obo
+++ b/apo.obo
@@ -132,7 +132,7 @@ is_a: APO:0000006 ! mutant_type
 
 [Term]
 id: APO:0000011
-name: null
+name: null mutant
 namespace: mutant_type
 alt_id: YPO:0000011
 def: "The mutation abolishes completely the function of the gene product." [SGD:RSN]
@@ -141,6 +141,7 @@ subset: CGD
 subset: CryptoGD
 subset: SGD
 synonym: "loss of function" RELATED [SGD:RSN]
+synonym: "null" EXACT []
 is_a: APO:0000006 ! mutant_type
 
 [Term]


### PR DESCRIPTION
APO:0000011 was causing issues for a user, as the old value was just `null`.  Trying to change name to `null mutant`, then add `null` as synonym, but not sure if there should be anything in the brackets.

If this works let me know if I need to make PRs to update header date/saved-by fields.