### PR TITLE
Update apo.obo

### DIFF
--- a/apo.obo
+++ b/apo.obo
@@ -8,11 +8,11 @@ subsetdef: phenotypeslim_cerevisiae "Phenotype Slim terms for S. cerevisiae"
 default-namespace: ascomycete_phenotype_ontology
 ontology: apo
 property_value: http://purl.org/dc/elements/1.1/modified "02:01:2021" xsd:string
-property_value: http://purl.org/dc/terms/contributor "Suzi Aleksander" xsd:string
-property_value: http://purl.org/dc/terms/contributor "Maria Costanzo" xsd:string
-property_value: http://purl.org/dc/terms/title "Ascomycete Phenotype Ontology (APO)" xsd:string
+property_value: http://purl.org/dc/elements/1.1/contributor "Suzi Aleksander" xsd:string
+property_value: http://purl.org/dc/elements/1.1/contributor "Maria Costanzo" xsd:string
+property_value: http://purl.org/dc/elements/1.1/title "Ascomycete Phenotype Ontology (APO)" xsd:string
 property_value: http://purl.org/dc/elements/1.1/description "A structured controlled vocabulary for the phenotypes of Ascomycete fungi." xsd:string
-property_value: http://purl.org/dc/terms/creator https://www.yeastgenome.org/
+property_value: http://purl.org/dc/elements/1.1/creator https://www.yeastgenome.org/
 property_value: http://purl.org/dc/terms/license http://creativecommons.org/licenses/by/4.0/
 remark: Filtered by Subset contains "SGD"; contact sgd-helpdesk@lists.stanford.edu
 auto-generated-by: OBO-Edit 2.1

--- a/apo.obo
+++ b/apo.obo
@@ -1,16 +1,22 @@
 format-version: 1.2
-date: 12:06:2015 14:28
-saved-by: mariacostanzo
-auto-generated-by: OBO-Edit 2.1
+date: 02:02:2021 14:22
 subsetdef: AspGD "APO terms in use at AspGD"
 subsetdef: CGD "APO terms in use at CGD"
 subsetdef: CryptoGD "APO terms in use at CryptoGD"
-subsetdef: phenotypeslim_cerevisiae "Phenotype Slim terms for S. cerevisiae"
 subsetdef: SGD "APO terms in use at SGD"
+subsetdef: phenotypeslim_cerevisiae "Phenotype Slim terms for S. cerevisiae"
 default-namespace: ascomycete_phenotype_ontology
-namespace-id-rule: * APO:$sequence(7,0000001,9999999)$
-remark: Filtered by Subset contains "SGD"
 ontology: apo
+property_value: http://purl.org/dc/elements/1.1/modified "02:01:2021" xsd:string
+property_value: http://purl.org/dc/terms/contributor "Suzi Aleksander" xsd:string
+property_value: http://purl.org/dc/terms/contributor "Maria Costanzo" xsd:string
+property_value: http://purl.org/dc/terms/title "Ascomycete Phenotype Ontology (APO)" xsd:string
+property_value: http://purl.org/dc/elements/1.1/description "A structured controlled vocabulary for the phenotypes of Ascomycete fungi." xsd:string
+property_value: http://purl.org/dc/terms/creator https://www.yeastgenome.org/
+property_value: http://purl.org/dc/terms/license http://creativecommons.org/licenses/by/4.0/
+remark: Filtered by Subset contains "SGD"; contact sgd-helpdesk@lists.stanford.edu
+auto-generated-by: OBO-Edit 2.1
+namespace-id-rule: * APO:$sequence(7,0000001,9999999)$
 
 [Term]
 id: APO:0000001


### PR DESCRIPTION
No changes to the terms here, just updating the header.  @matentzn, lines 18-19 are the only ones I couldn't figure out how to conform to DCMI, are they ok to leave as-is? There's http://purl.org/dc/terms/hasFormat but I don't know if that's appropriate for line 19, currently `namespace-id-rule: * APO:$sequence(7,0000001,9999999)$`  
Thanks for any guidance.

The rest of the lines are in the right (hopefully?) format or at least also found in other recently updated OBOs.

